### PR TITLE
Make @SystemProperty a @Repeatable annotation

### DIFF
--- a/docs/systemProperty.md
+++ b/docs/systemProperty.md
@@ -34,7 +34,7 @@ public void aTest() {
 }
 ```
 
-These approaches will work but they are verbose and brittle. The `SystemPropertyExtension` allows you to _declare_ this behaviour by adding the `@SystemProperty` annotation (or its repeating equivalent: `@SystemProperties`) to a test case or a test method. This annotation allows you to declare:
+These approaches will work but they are verbose and brittle. The `SystemPropertyExtension` allows you to _declare_ this behaviour by adding the `@SystemProperty` annotation to a test case or a test method. This annotation allows you to declare:
                                                                        
 - `name`: the system property name
 - `value`: The system property value
@@ -57,12 +57,8 @@ public class MyTest {
 ###### Class Level System Properties
 
 ```
-@SystemProperties(
-  properties = {
-    @SystemProperty(name = "x", value = "y"),
-    @SystemProperty(name = "p", value = "q")
-  }
-)
+@SystemProperty(name = "x", value = "y")
+@SystemProperty(name = "p", value = "q")
 public class MyTest {
 
     @Test
@@ -92,12 +88,8 @@ public class MyTest {
 public class MyTest {
 
     @Test
-    @SystemProperties(
-      properties = {
-        @SystemProperty(name = "x", value = "y"),
-        @SystemProperty(name = "p", value = "q")
-      }
-    )
+    @SystemProperty(name = "x", value = "y")
+    @SystemProperty(name = "p", value = "q")
     public void aTes() {
         assertThat(System.getProperty("x"), is("y"));
         assertThat(System.getProperty("p"), is("q"));

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.glytching</groupId>
     <artifactId>junit-extensions</artifactId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JUnit Extensions</name>

--- a/src/main/java/io/github/glytching/junit/extension/system/SystemProperties.java
+++ b/src/main/java/io/github/glytching/junit/extension/system/SystemProperties.java
@@ -28,12 +28,8 @@ import java.lang.annotation.*;
  *
  * <pre>
  *  // set the system properties nameA:valueA and nameB:valueB
- *  &#064;SystemProperties(
- *      properties = {
- *          &#064;SystemProperty(name = "nameA", value = "valueA"),
- *          &#064;SystemProperty(name = "nameB", value = "valueB")
- *      }
- *  )
+ *  &#064;SystemProperty(name = "nameA", value = "valueA")
+ *  &#064;SystemProperty(name = "nameB", value = "valueB")
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -42,5 +38,5 @@ import java.lang.annotation.*;
 @ExtendWith(SystemPropertyExtension.class)
 public @interface SystemProperties {
 
-  SystemProperty[] properties();
+  SystemProperty[] value();
 }

--- a/src/main/java/io/github/glytching/junit/extension/system/SystemProperty.java
+++ b/src/main/java/io/github/glytching/junit/extension/system/SystemProperty.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.lang.annotation.*;
 
+
 /**
  * Declares a system property to be set before a test. This annotation can be used at class level
  * and at method level.
@@ -34,10 +35,11 @@ import java.lang.annotation.*;
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
 @Documented
+@Repeatable(value = SystemProperties.class)
 @ExtendWith(SystemPropertyExtension.class)
 public @interface SystemProperty {
 
-  String name();
+    String name();
 
-  String value();
+    String value();
 }

--- a/src/main/java/io/github/glytching/junit/extension/system/SystemPropertyExtension.java
+++ b/src/main/java/io/github/glytching/junit/extension/system/SystemPropertyExtension.java
@@ -61,20 +61,15 @@ import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
  * </pre>
  * </ul>
  *
- * <p>Multiple system properties can be declared using the {@link SystemProperties} repeating
- * annotation.
+ * <p>The {@link SystemProperty} annotation is repeatable.
  *
  * <p>Usage examples:
  *
  * <p>Declaring system properties at class level:
  *
  * <pre>
- *  &#064;SystemProperties(
- *      properties = {
- *          &#064;SystemProperty(name = "nameA", value = "valueA"),
- *          &#064;SystemProperty(name = "nameB", value = "valueB")
- *      }
- *  )
+ *  &#064;SystemProperty(name = "nameA", value = "valueA")
+ *  &#064;SystemProperty(name = "nameB", value = "valueB")
  * public class MyTest {
  *
  *     &#064;Test
@@ -91,12 +86,8 @@ import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
  * public class MyTest {
  *
  *     &#064;Test
- *     &#064;SystemProperties(
- *         properties = {
- *            &#064;SystemProperty(name = "nameA", value = "valueA"),
- *            &#064;SystemProperty(name = "nameB", value = "valueB")
- *         }
- *     )
+ *     &#064;SystemProperty(name = "nameA", value = "valueA")
+ *     &#064;SystemProperty(name = "nameB", value = "valueB")
  *     public void testUsingSystemProperties(TemporaryFolder temporaryFolder) {
  *         // the system properties nameA:valueA, nameB:valueB have been set
  *         // ...
@@ -233,9 +224,9 @@ public class SystemPropertyExtension
   private List<SystemProperty> getSystemProperties(AnnotatedElement annotatedElement) {
     List<SystemProperty> systemProperties = new ArrayList<>();
     if (isAnnotated(annotatedElement, SystemProperties.class)) {
-      // gather than repeating system property values
+      // gather the repeating system property values
       systemProperties.addAll(
-          Arrays.asList(annotatedElement.getAnnotation(SystemProperties.class).properties()));
+          Arrays.asList(annotatedElement.getAnnotation(SystemProperties.class).value()));
     }
     if (isAnnotated(annotatedElement, SystemProperty.class)) {
       // add the single system property value

--- a/src/test/java/io/github/glytching/junit/extension/system/SystemPropertyExtensionClassTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/system/SystemPropertyExtensionClassTest.java
@@ -22,12 +22,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @SystemProperty(name = "classPropertyKeyC", value = "classPropertyValueC")
-@SystemProperties(
-  properties = {
-    @SystemProperty(name = "classPropertyKeyA", value = "classPropertyValueA"),
-    @SystemProperty(name = "classPropertyKeyB", value = "classPropertyValueB")
-  }
-)
+@SystemProperty(name = "classPropertyKeyA", value = "classPropertyValueA")
+@SystemProperty(name = "classPropertyKeyB", value = "classPropertyValueB")
 public class SystemPropertyExtensionClassTest {
 
   @Test

--- a/src/test/java/io/github/glytching/junit/extension/system/SystemPropertyExtensionMethodTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/system/SystemPropertyExtensionMethodTest.java
@@ -30,12 +30,8 @@ public class SystemPropertyExtensionMethodTest {
   }
 
   @Test
-  @SystemProperties(
-    properties = {
-      @SystemProperty(name = "keyA", value = "valueA"),
-      @SystemProperty(name = "keyB", value = "valueB")
-    }
-  )
+  @SystemProperty(name = "keyA", value = "valueA")
+  @SystemProperty(name = "keyB", value = "valueB")
   public void canSetSystemProperties() {
     assertThat(System.getProperty("keyA"), is("valueA"));
     assertThat(System.getProperty("keyB"), is("valueB"));


### PR DESCRIPTION
## Proposed Change

Make `@SystemProperty` a `@Repeatable` annotation

See: https://github.com/glytching/junit-extensions/issues/1

## Type Of Change

What type of change does this PR introduce?

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected) - Any existing usage of `junit-extensions` which uses the previous way of expressing multiple `@SystemProperty` annotations will have to change from:

```
  @SystemProperties(
    properties = {
      @SystemProperty(name = "keyA", value = "valueA"),
      @SystemProperty(name = "keyB", value = "valueB")
    }
)
```

...to:

```
  @SystemProperty(name = "keyA", value = "valueA")
  @SystemProperty(name = "keyB", value = "valueB")
```


## Checklist

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] All unit tests pass locally with my changes
- [x] I have updated the existing tests, these tests already cover the behaviour of multiple `@SystemProperty` annotations and these tests pass with the new way of expressing multiple `@SystemProperty` annotations
- [x] I have added necessary documentation 
