### PR TITLE
The ExpectedExceptionExtension now asserts failure if no exception ha…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.github.glytching</groupId>
     <artifactId>junit-extensions</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JUnit Extensions</name>

--- a/src/main/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtension.java
+++ b/src/main/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtension.java
@@ -17,8 +17,8 @@
 package io.github.glytching.junit.extension.folder;
 
 import org.junit.jupiter.api.extension.*;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.jupiter.api.extension.ExtensionContext.Store;
+
+import static io.github.glytching.junit.extension.util.ExtensionUtil.getStore;
 
 /**
  * The temporary folder extension provides a test with access to temporary files and directories.
@@ -117,7 +117,8 @@ public class TemporaryFolderExtension implements AfterEachCallback, ParameterRes
    */
   @Override
   public void afterEach(ExtensionContext extensionContext) {
-    TemporaryFolder temporaryFolder = getStore(extensionContext).get(KEY, TemporaryFolder.class);
+    TemporaryFolder temporaryFolder =
+        getStore(extensionContext, this.getClass()).get(KEY, TemporaryFolder.class);
     if (temporaryFolder != null) {
       try {
         temporaryFolder.destroy();
@@ -159,39 +160,11 @@ public class TemporaryFolderExtension implements AfterEachCallback, ParameterRes
   public Object resolveParameter(
       ParameterContext parameterContext, ExtensionContext extensionContext)
       throws ParameterResolutionException {
-    return getStore(extensionContext).getOrComputeIfAbsent(KEY, key -> new TemporaryFolder());
+    return getStore(extensionContext, this.getClass())
+        .getOrComputeIfAbsent(KEY, key -> new TemporaryFolder());
   }
 
   private boolean appliesTo(Class<?> clazz) {
     return clazz == TemporaryFolder.class;
-  }
-
-  /**
-   * Creates a {@link Store} for a {@link TemporaryFolder} in the context of the given {@code
-   * extensionContext}. A {@link Store} is bound to an {@link ExtensionContext} so different test
-   * invocations do not share the same store. For example a test invocation on {@code
-   * ClassA.testMethodA} will have a different {@link Store} instance to that associated with a test
-   * invocation on {@code ClassA.testMethodB} or test invocation on {@code ClassC.testMethodC}.
-   *
-   * @param extensionContext the <em>context</em> in which the current test or container is being
-   *     executed
-   * @return a {@link Store} for the given {@code extensionContext}
-   */
-  private Store getStore(ExtensionContext extensionContext) {
-    return extensionContext.getStore(namespace(extensionContext));
-  }
-
-  /**
-   * Creates a {@link Namespace} in which {@link TemporaryFolder}s are stored on creation for post
-   * execution destruction. Storing data in a custom namespace prevents accidental cross pollination
-   * of data between extensions and between different invocations within the lifecycle of a single
-   * extension.
-   *
-   * @param extensionContext the <em>context</em> in which the current test or container is being
-   *     executed
-   * @return a {@link Namespace} describing the scope for a single {@link TemporaryFolder}
-   */
-  private Namespace namespace(ExtensionContext extensionContext) {
-    return Namespace.create(this.getClass(), extensionContext);
   }
 }

--- a/src/main/java/io/github/glytching/junit/extension/system/SystemPropertyExtension.java
+++ b/src/main/java/io/github/glytching/junit/extension/system/SystemPropertyExtension.java
@@ -17,14 +17,13 @@
 package io.github.glytching.junit.extension.system;
 
 import org.junit.jupiter.api.extension.*;
-import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
-import org.junit.jupiter.api.extension.ExtensionContext.Store;
 
 import java.lang.reflect.AnnotatedElement;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static io.github.glytching.junit.extension.util.ExtensionUtil.getStore;
 import static org.junit.platform.commons.util.AnnotationUtils.isAnnotated;
 
 /**
@@ -241,39 +240,10 @@ public class SystemPropertyExtension
 
   private void writeRestoreContext(
       ExtensionContext extensionContext, RestoreContext restoreContext) {
-    getStore(extensionContext).getOrComputeIfAbsent(KEY, key -> restoreContext);
+    getStore(extensionContext, this.getClass()).getOrComputeIfAbsent(KEY, key -> restoreContext);
   }
 
   private RestoreContext readRestoreContext(ExtensionContext extensionContext) {
-    return getStore(extensionContext).get(KEY, RestoreContext.class);
-  }
-
-  /**
-   * Creates a {@link Store} for a {@link RestoreContext} in the context of the given {@code
-   * extensionContext}. A {@link Store} is bound to an {@link ExtensionContext} so different test
-   * invocations do not share the same store. For example a test invocation on {@code
-   * ClassA.testMethodA} will have a different {@link Store} instance to that associated with a test
-   * invocation on {@code ClassA.testMethodB} or test invocation on {@code ClassC.testMethodC}.
-   *
-   * @param extensionContext the <em>context</em> in which the current test or container is being
-   *     executed
-   * @return a {@link Store} for the given {@code extensionContext}
-   */
-  private Store getStore(ExtensionContext extensionContext) {
-    return extensionContext.getRoot().getStore(namespace(extensionContext));
-  }
-
-  /**
-   * Creates a {@link Namespace} in which {@link RestoreContext}s are stored on creation for post
-   * execution restoration. Storing data in a custom namespace prevents accidental cross pollination
-   * of data between extensions and between different invocations within the lifecycle of a single
-   * extension.
-   *
-   * @param extensionContext the <em>context</em> in which the current test or container is being
-   *     executed
-   * @return a {@link Namespace} describing the scope for a single {@link RestoreContext}
-   */
-  private Namespace namespace(ExtensionContext extensionContext) {
-    return Namespace.create(this.getClass(), extensionContext);
+    return getStore(extensionContext, this.getClass()).get(KEY, RestoreContext.class);
   }
 }

--- a/src/main/java/io/github/glytching/junit/extension/util/ExtensionUtil.java
+++ b/src/main/java/io/github/glytching/junit/extension/util/ExtensionUtil.java
@@ -1,0 +1,35 @@
+package io.github.glytching.junit.extension.util;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+public class ExtensionUtil {
+
+  /**
+   * Creates a {@link ExtensionContext.Store} for a given {@code extensionContext}. A {@link
+   * ExtensionContext.Store} is bound to an {@link ExtensionContext} so different test invocations
+   * do not share the same store. For example a test invocation on {@code ClassA.testMethodA} will
+   * have a different {@link ExtensionContext.Store} instance to that associated with a test
+   * invocation on {@code ClassA.testMethodB} or test invocation on {@code ClassC.testMethodC}.
+   *
+   * @param extensionContext the <em>context</em> in which the current test or container is being
+   *     executed
+   * @return a {@link ExtensionContext.Store} for the given {@code extensionContext}
+   */
+  public static ExtensionContext.Store getStore(ExtensionContext extensionContext, Class clazz) {
+    return extensionContext.getStore(namespace(extensionContext, clazz));
+  }
+
+  /**
+   * Creates a {@link ExtensionContext.Namespace} in which extension state is stored on creation for
+   * post execution destruction. Storing data in a custom namespace prevents accidental cross
+   * pollination of data between extensions and between different invocations within the lifecycle
+   * of a single extension.
+   *
+   * @param extensionContext the <em>context</em> in which the current test or container is being
+   *     executed
+   * @return a {@link ExtensionContext.Namespace} describing the scope for an extension
+   */
+  private static ExtensionContext.Namespace namespace(ExtensionContext extensionContext, Class clazz) {
+    return ExtensionContext.Namespace.create(clazz, extensionContext);
+  }
+}

--- a/src/test/java/io/github/glytching/junit/extension/exception/ExpectedExceptionExtensionMetaTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/exception/ExpectedExceptionExtensionMetaTest.java
@@ -171,6 +171,4 @@ public class ExpectedExceptionExtensionMetaTest {
   private Method getMethod(String methodName) throws NoSuchMethodException {
     return ExpectedExceptionExtensionTest.class.getMethod(methodName);
   }
-
-  public void foo() {}
 }

--- a/src/test/java/io/github/glytching/junit/extension/exception/ExpectedExceptionExtensionMetaTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/exception/ExpectedExceptionExtensionMetaTest.java
@@ -21,13 +21,18 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opentest4j.AssertionFailedError;
 
 import java.lang.reflect.Method;
 import java.util.Optional;
+import java.util.function.Function;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.extension.ExtensionContext.Namespace.create;
+import static org.junit.jupiter.api.extension.ExtensionContext.Store;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -39,7 +44,9 @@ import static org.mockito.Mockito.when;
 public class ExpectedExceptionExtensionMetaTest {
 
   private final ExpectedExceptionExtension sut = new ExpectedExceptionExtension();
+
   @Mock private ExtensionContext extensionContext;
+  @Mock private Store store;
 
   @BeforeEach
   public void initMocks() {
@@ -76,7 +83,7 @@ public class ExpectedExceptionExtensionMetaTest {
   @Test
   public void willRethrowIfTheExceptionMessageDoesNotStartWithTheExpectedExceptionMessage()
       throws Throwable {
-    givenExtensionContentWithMethod("canHandleARuntimeException");
+    givenExtensionContentWithMethod("canHandleAnExceptionWithAMessageWhichStartsWith");
 
     RuntimeException expected = new RuntimeException("Foo");
 
@@ -90,7 +97,7 @@ public class ExpectedExceptionExtensionMetaTest {
   @Test
   public void willRethrowIfTheExceptionMessageDoesNotContainTheExpectedExceptionMessage()
       throws Throwable {
-    givenExtensionContentWithMethod("canHandleARuntimeException");
+    givenExtensionContentWithMethod("canHandleAnExceptionWithAMessageWhichContains");
 
     RuntimeException expected = new RuntimeException("Bar");
 
@@ -101,6 +108,62 @@ public class ExpectedExceptionExtensionMetaTest {
     assertThat(actual, is(expected));
   }
 
+  /**
+   * @throws Throwable
+   * @see <a href="https://github.com/glytching/junit-extensions/issues/3"></a>
+   */
+  @Test
+  public void willAssertFailureIfAnExceptionIsNeitherThrownNorHandled() throws Throwable {
+    when(extensionContext.getStore(create(ExpectedExceptionExtension.class, extensionContext)))
+        .thenReturn(store);
+
+    // no exception was handled by the extension
+    when(store.getOrComputeIfAbsent(any(String.class), any(Function.class))).thenReturn(false);
+
+    // the extension context does not contain an exception
+    when(extensionContext.getExecutionException()).thenReturn(Optional.empty());
+
+    AssertionFailedError actual =
+        assertThrows(AssertionFailedError.class, () -> sut.afterTestExecution(extensionContext));
+    assertThat(actual.getMessage(), is("Expected an exception but no exception was thrown!"));
+  }
+
+  /**
+   * @throws Throwable
+   * @see <a href="https://github.com/glytching/junit-extensions/issues/3"></a>
+   */
+  @Test
+  public void willNotAssertFailureIfTheExceptionContextContainsAnException() throws Throwable {
+    when(extensionContext.getStore(create(ExpectedExceptionExtension.class, extensionContext)))
+        .thenReturn(store);
+
+    // no exception was handled by the extension
+    when(store.getOrComputeIfAbsent(any(String.class), any(Function.class))).thenReturn(false);
+
+    // the extension context contains an exception
+    when(extensionContext.getExecutionException()).thenReturn(Optional.of(new Exception("boom!")));
+
+    sut.afterTestExecution(extensionContext);
+  }
+
+  /**
+   * @throws Throwable
+   * @see <a href="https://github.com/glytching/junit-extensions/issues/3"></a>
+   */
+  @Test
+  public void willNotAssertFailureIfTheExceptionIsHandled() throws Throwable {
+    when(extensionContext.getStore(create(ExpectedExceptionExtension.class, extensionContext)))
+        .thenReturn(store);
+
+    // an exception was handled by the extension
+    when(store.getOrComputeIfAbsent(any(String.class), any(Function.class))).thenReturn(true);
+
+    // the extension context does not contains an exception
+    when(extensionContext.getExecutionException()).thenReturn(Optional.empty());
+
+    sut.afterTestExecution(extensionContext);
+  }
+
   private void givenExtensionContentWithMethod(String methodName) throws NoSuchMethodException {
     when(extensionContext.getTestMethod()).thenReturn(Optional.of(getMethod(methodName)));
   }
@@ -108,4 +171,6 @@ public class ExpectedExceptionExtensionMetaTest {
   private Method getMethod(String methodName) throws NoSuchMethodException {
     return ExpectedExceptionExtensionTest.class.getMethod(methodName);
   }
+
+  public void foo() {}
 }


### PR DESCRIPTION
## Proposed Change

The presence of `@ExpectedException` on a test is a clear statement by the developer that _some_ exception _must_ be thrown by that test. The following test shows a scenario in which this expectation is not being met: 

```
  @Test
  @ExpectedException(type = Throwable.class)
  public void failsTestForMissingException() {}
```

The purpose of this PR is to fill that gap such that this false positive cannot occur.

See [#3](https://github.com/glytching/junit-extensions/issues/3).

## Type Of Change

What type of change does this PR introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] All unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

The key changes here are in `ExpectedExceptionExtension` and `ExpectedExceptionExtensionMetaTest`, the remaining changes arise from refactoring the common `getStore` code into a utility class. With these changes to `ExpectedExceptionExtension` the number of usages of that code warrants a shared implementation of it.

With the changes in this PR, this test will now fail:

```
  @Test
  @ExpectedException(type = Throwable.class)
  public void failsTestForMissingException() {}
```

Like so:

```
org.opentest4j.AssertionFailedError: Expected an exception but no exception was thrown!

     at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:48)
     at org.junit.jupiter.api.AssertionUtils.fail(AssertionUtils.java:36)
     at org.junit.jupiter.api.Assertions.fail(Assertions.java:57)
     at io.github.glytching.junit.extension.exception.ExpectedExceptionExtension.afterTestExecution(ExpectedExceptionExtension.java:119)
     ...
 ```
 
The new behaviour is implemented in `ExpectedExceptionExtension.afterTestExecution`. The Javadoc for `ExpectedExceptionExtension` has been updated to make this clear and the new behaviour is tested in `ExpectedExceptionExtensionMetaTest`.

 - `willAssertFailureIfAnExceptionIsNeitherThrownNorHandled`
 - `willNotAssertFailureIfTheExceptionContextContainsAnException`
 - `willNotAssertFailureIfTheExceptionIsHandled`