### PR TITLE
Exposed TemporaryFolder.getRoot() for ease of migration from JUnit4's TemporaryFolder rule

### DIFF
--- a/docs/temporaryFolder.md
+++ b/docs/temporaryFolder.md
@@ -21,9 +21,14 @@ public class MyTest {
  
     @Test
     public void canUseTemporaryFolder() throws IOException {
+        // use the temporary folder itself
+        File root = temporaryFolder.getRoot();
+
+        // create a file within the temporary folder
         File file = temporaryFolder.createFile("foo.txt");
         assertThat(file.exists(), is(true));
  
+        // create a directory within the temporary folder
         File dir = temporaryFolder.createDirectory("bar");
         assertThat(dir.exists(), is(true));
     } 
@@ -38,9 +43,14 @@ public class MyTest {
     @Test
     @ExtendWith(TemporaryFolderExtension.class)
     public void canUseTemporaryFolder(TemporaryFolder temporaryFolder) throws IOException {
+        // use the temporary folder itself
+        File root = temporaryFolder.getRoot();
+
+        // create a file within the temporary folder    
         File file = temporaryFolder.createFile("foo.txt");
         assertThat(file.exists(), is(true));
     
+        // create a directory within the temporary folder
         File dir = temporaryFolder.createDirectory("bar");
         assertThat(dir.exists(), is(true));
     }

--- a/src/main/java/io/github/glytching/junit/extension/folder/TemporaryFolder.java
+++ b/src/main/java/io/github/glytching/junit/extension/folder/TemporaryFolder.java
@@ -57,6 +57,23 @@ public class TemporaryFolder {
   }
 
   /**
+   * Returns the root folder. Exposing this offers some back compatability with JUnit4's {@code
+   * TemporaryFolder} so test cases which are used to invoking {@code getRoot()} on a JUnit4 rule
+   * can adopt the same approach with this {@code TemporaryFolder}. In addition, this may be useful
+   * where you want to use the root folder itself without creating files or directories within it.
+   *
+   * <p><b>Note:</b> the extension is responsible for creating/managing/destroying the root folder
+   * so don't bother trying to clean it up yourself and don't expect that anything you do to it will
+   * survive post-test-cleanup.
+   *
+   * @see <a href="https://github.com/glytching/junit-extensions/issues/8">Issue 8</a>
+   * @return the root folder
+   */
+  public File getRoot() {
+    return rootFolder;
+  }
+
+  /**
    * Create a file within the temporary folder root.
    *
    * @param fileName the name of the file to be created

--- a/src/main/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtension.java
+++ b/src/main/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtension.java
@@ -73,6 +73,10 @@ import static io.github.glytching.junit.extension.util.ExtensionUtil.getStore;
  *
  *     &#064;Test
  *     public void testUsingTemporaryDirectory() {
+ *         // use the temporary folder itself
+ *         File root = temporaryFolder.getRoot();
+ *
+ *         // create a sub directory within the temporary folder
  *         File file = temporaryFolder.createDirectory("foo");
  *         // ...
  *     }
@@ -94,6 +98,10 @@ import static io.github.glytching.junit.extension.util.ExtensionUtil.getStore;
  *     &#064;Test
  *     &#064;ExtendWith(TemporaryFolderExtension.class)
  *     public void testUsingTemporaryDirectory(TemporaryFolder temporaryFolder) {
+ *         // use the temporary folder itself
+ *         File root = temporaryFolder.getRoot();
+ *
+ *         // create a sub directory within the temporary folder
  *         File file = temporaryFolder.createDirectory("foo");
  *         // ...
  *     }

--- a/src/test/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtensionFieldTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtensionFieldTest.java
@@ -81,6 +81,15 @@ public class TemporaryFolderExtensionFieldTest {
     assertThat(dir.exists(), is(true));
   }
 
+  @Test
+  public void canGetTheRootFolderWhenATemporaryFolderIsInjectedAsAField() throws IOException {
+    File root = temporaryFolder.getRoot();
+    assertThat(root.exists(), is(true));
+
+    File dir = temporaryFolder.createDirectory("bar");
+    assertThat(dir.getParentFile(), is(root));
+  }
+
   @RepeatedTest(5)
   public void willCreateANewTemporaryFileEveryTime() throws IOException {
     File file = temporaryFolder.createFile("foo.txt");

--- a/src/test/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtensionParameterTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/folder/TemporaryFolderExtensionParameterTest.java
@@ -76,6 +76,18 @@ public class TemporaryFolderExtensionParameterTest {
     assertThat(dir.exists(), is(true));
   }
 
+  @Test
+  @ExtendWith(TemporaryFolderExtension.class)
+  public void canGetTheRootFolderWhenATemporaryFolderIsInjectedAsAParameter(TemporaryFolder temporaryFolder)
+      throws IOException {
+    File root = temporaryFolder.getRoot();
+
+    assertThat(root.exists(), is(true));
+
+    File dir = temporaryFolder.createDirectory("bar");
+    assertThat(dir.getParentFile(), is(root));
+  }
+
   @RepeatedTest(5)
   @ExtendWith(TemporaryFolderExtension.class)
   public void willCreateANewTemporaryFileEveryTime(TemporaryFolder temporaryFolder)


### PR DESCRIPTION
## Proposed Change

Expose `TemporaryFolder.getRoot()` for ease of migration from JUnit4's TemporaryFolder rule.

See: https://github.com/glytching/junit-extensions/issues/8

## Type Of Change

What type of change does this PR introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [x] All unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
