### PR TITLE
Added Option to Provide Randomization parameters for RandomBeansExtension

### DIFF
--- a/docs/randomBeans.md
+++ b/docs/randomBeans.md
@@ -140,3 +140,45 @@ public class RandomBeansExtensionParameterTest {
     }
 }
 ```
+
+##### Providing Randomization parameters 
+In some cases if you want to provide [Randomization parameters](https://github.com/j-easy/easy-random/wiki/Randomization-parameters), In that case you need to register extension using `    @RegisterExtension
+`      
+```
+public class RandomBeansExtensionProgrammaticRegistrationTest {
+
+    static EnhancedRandom enhancedRandom = EnhancedRandomBuilder
+            .aNewEnhancedRandomBuilder()
+            .exclude(FieldDefinitionBuilder
+                    .field()
+                    .named("wotsits")
+                    .ofType(List.class)
+                    .inClass(DomainObject.class)
+                    .get())
+            .randomize(Integer.class, IntegerRangeRandomizer.aNewIntegerRangeRandomizer(0, 10))
+            .randomize(String.class, StringRandomizer.aNewStringRandomizer(5))
+            .randomize(Double.class, DoubleRangeRandomizer.aNewDoubleRangeRandomizer(0.0, 10.0))
+            .build();
+
+    
+    @RegisterExtension
+    static RandomBeansExtension randomBeansExtension = new RandomBeansExtension(enhancedRandom);
+
+   
+    @Test
+     public void canInjectIntegerInRangeOf(
+            @Random(type = Integer.class) Integer anyInteger) throws Exception {
+            // supplied with Random Integer in  range of 0,10
+      }
+      
+      @Test
+      public void canInjectDoubleInRangeOf(
+                 @Random(type = Double.class) Double anyDouble) throws Exception {
+                  // supplied with Random Double in  range of 0.0,10.0
+      }  
+       @Test
+       public void canInjectAPartiallyPopulatedObject(@Random DomainObject domainObject) {
+         // supplied with DomainObject excluding property wotsits of type List 
+       }  
+}
+```

--- a/docs/randomBeans.md
+++ b/docs/randomBeans.md
@@ -141,9 +141,10 @@ public class RandomBeansExtensionParameterTest {
 }
 ```
 
-##### Providing Randomization parameters 
-In some cases if you want to provide [Randomization parameters](https://github.com/j-easy/easy-random/wiki/Randomization-parameters), In that case you need to register extension using `    @RegisterExtension
-`      
+##### Overriding the Default Randomization Parameters
+ 
+In the event that the default [randomization parameters](https://github.com/j-easy/easy-random/wiki/Randomization-parameters) declared by this extension are not sufficient/appropriate for your use, you can override the defaults by using `@RegisterExtension` to pass in your own instance of RandomBeans' `EnhancedRandom`. For example:      
+
 ```
 public class RandomBeansExtensionProgrammaticRegistrationTest {
 
@@ -163,22 +164,21 @@ public class RandomBeansExtensionProgrammaticRegistrationTest {
     
     @RegisterExtension
     static RandomBeansExtension randomBeansExtension = new RandomBeansExtension(enhancedRandom);
-
    
     @Test
-     public void canInjectIntegerInRangeOf(
-            @Random(type = Integer.class) Integer anyInteger) throws Exception {
-            // supplied with Random Integer in  range of 0,10
-      }
+    public void canInjectIntegerInRangeOf(
+        @Random(type = Integer.class) Integer anyInteger) throws Exception {
+        assertThat(anyInteger, notNullValue());
+        assertThat(anyInteger, lessThanOrEqualTo(10));
+        assertThat(anyInteger, greaterThanOrEqualTo(0));
+    }
       
-      @Test
-      public void canInjectDoubleInRangeOf(
-                 @Random(type = Double.class) Double anyDouble) throws Exception {
-                  // supplied with Random Double in  range of 0.0,10.0
-      }  
-       @Test
-       public void canInjectAPartiallyPopulatedObject(@Random DomainObject domainObject) {
-         // supplied with DomainObject excluding property wotsits of type List 
-       }  
+    @Test
+    public void canInjectDoubleInRangeOf(
+        @Random(type = Double.class) Double anyDouble) throws Exception {
+        assertThat(anyDouble, notNullValue());
+        assertThat(anyDouble, lessThanOrEqualTo(10.0));
+        assertThat(anyDouble, greaterThanOrEqualTo(0.0));
+    }
 }
 ```

--- a/src/main/java/io/github/glytching/junit/extension/random/RandomBeansExtension.java
+++ b/src/main/java/io/github/glytching/junit/extension/random/RandomBeansExtension.java
@@ -121,14 +121,13 @@ public class RandomBeansExtension implements TestInstancePostProcessor, Paramete
   private final EnhancedRandom random;
 
   /**
-   * Create the extension with its encapsulated {@link EnhancedRandom}.
+   * Create the extension with a default {@link EnhancedRandom}.
    *
    * @see <a href="https://github.com/benas/random-beans/wiki/Randomization-parameters">Enhanced
    *     Random Configuration Parameters</a>
    */
   public RandomBeansExtension() {
-    this.random =
-        EnhancedRandomBuilder.aNewEnhancedRandomBuilder()
+    this(EnhancedRandomBuilder.aNewEnhancedRandomBuilder()
             // maximum number of instances of a given type, above this number requests will start to
             // reuse
             // previously generated instances
@@ -153,15 +152,13 @@ public class RandomBeansExtension implements TestInstancePostProcessor, Paramete
 
             // do not override any values which are already initialised in the target type
             .overrideDefaultInitialization(false)
-            .build();
+            .build());
   }
 
   /**
-   * Initialize random bean with provided configuration.
-   * Custom configuration can be provided by Registering RandomBeanExtension using @RegisterExtension annotation
-   *
-   * Registering RandomBean extension using programmatic approach allows to overrider any default configuration
-   * of random bean
+   * Create the extension with the given {@link EnhancedRandom}. This is used, instead of the zero-arg alternative, when
+   * the caller wants to override the default 'randomizer' configuration. This constructor will be called by using the
+   * {@code RegisterExtension} annotation.
    *
    * @param enhancedRandom
    */

--- a/src/main/java/io/github/glytching/junit/extension/random/RandomBeansExtension.java
+++ b/src/main/java/io/github/glytching/junit/extension/random/RandomBeansExtension.java
@@ -157,6 +157,20 @@ public class RandomBeansExtension implements TestInstancePostProcessor, Paramete
   }
 
   /**
+   * Initialize random bean with provided configuration.
+   * Custom configuration can be provided by Registering RandomBeanExtension using @RegisterExtension annotation
+   *
+   * Registering RandomBean extension using programmatic approach allows to overrider any default configuration
+   * of random bean
+   *
+   * @param enhancedRandom
+   */
+  public RandomBeansExtension(EnhancedRandom enhancedRandom) {
+    this.random = enhancedRandom;
+
+  }
+
+  /**
    * Does this extension support injection for parameters of the type described by the given {@code
    * parameterContext}?
    *

--- a/src/test/java/io/github/glytching/junit/extension/random/RandomBeansExtensionOverrideTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/random/RandomBeansExtensionOverrideTest.java
@@ -37,8 +37,7 @@ import static io.github.glytching.junit.extension.util.AssertionUtil.getDefaultS
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
-public class RandomBeansExtensionProgrammaticRegistrationTest {
-
+public class RandomBeansExtensionOverrideTest {
 
     static EnhancedRandom enhancedRandom = EnhancedRandomBuilder
             .aNewEnhancedRandomBuilder()
@@ -60,8 +59,6 @@ public class RandomBeansExtensionProgrammaticRegistrationTest {
     // each test
     private final Set<String> anyStrings = new HashSet<>();
 
-
-
     @Test
     @RepeatedTest(5)
     public void canOverrideDefaultIntegerRangeByProgrammaticExtensionRegistration(
@@ -77,6 +74,7 @@ public class RandomBeansExtensionProgrammaticRegistrationTest {
             @Random(type = Double.class) Double anyDouble) throws Exception {
         assertThat(anyDouble, notNullValue());
         assertThat(anyDouble, lessThanOrEqualTo(10.0));
+        assertThat(anyDouble, greaterThanOrEqualTo(0.0));
     }
 
     @Test
@@ -136,7 +134,6 @@ public class RandomBeansExtensionProgrammaticRegistrationTest {
         assertThat(anyCollection, not(empty()));
         assertThat(anyCollection.size(), is(getDefaultSizeOfRandom()));
     }
-
 
     @RepeatedTest(5)
     public void willInjectANewRandomValueEachTimeWithProgrammaticExtensionRegistration(@Random String anyString) {

--- a/src/test/java/io/github/glytching/junit/extension/random/RandomBeansExtensionProgrammaticRegistrationTest.java
+++ b/src/test/java/io/github/glytching/junit/extension/random/RandomBeansExtensionProgrammaticRegistrationTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.glytching.junit.extension.random;
+
+import io.github.benas.randombeans.EnhancedRandomBuilder;
+import io.github.benas.randombeans.FieldDefinitionBuilder;
+import io.github.benas.randombeans.api.EnhancedRandom;
+import io.github.benas.randombeans.randomizers.range.DoubleRangeRandomizer;
+import io.github.benas.randombeans.randomizers.range.IntegerRangeRandomizer;
+import io.github.benas.randombeans.randomizers.text.StringRandomizer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static io.github.glytching.junit.extension.util.AssertionUtil.getDefaultSizeOfRandom;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class RandomBeansExtensionProgrammaticRegistrationTest {
+
+
+    static EnhancedRandom enhancedRandom = EnhancedRandomBuilder
+            .aNewEnhancedRandomBuilder()
+            .exclude(FieldDefinitionBuilder
+                    .field()
+                    .named("wotsits")
+                    .ofType(List.class)
+                    .inClass(DomainObject.class)
+                    .get())
+            .randomize(Integer.class, IntegerRangeRandomizer.aNewIntegerRangeRandomizer(0, 10))
+            .randomize(String.class, StringRandomizer.aNewStringRandomizer(5))
+            .randomize(Double.class, DoubleRangeRandomizer.aNewDoubleRangeRandomizer(0.0, 10.0))
+            .build();
+
+    @RegisterExtension
+    static RandomBeansExtension randomBeansExtension = new RandomBeansExtension(enhancedRandom);
+
+    // gather the random values to facilitate assertions on the distinct-ness of the value supplied to
+    // each test
+    private final Set<String> anyStrings = new HashSet<>();
+
+
+
+    @Test
+    @RepeatedTest(5)
+    public void canOverrideDefaultIntegerRangeByProgrammaticExtensionRegistration(
+            @Random(type = Integer.class) Integer anyInteger) throws Exception {
+        assertThat(anyInteger, notNullValue());
+        assertThat(anyInteger, lessThanOrEqualTo(10));
+        assertThat(anyInteger, greaterThanOrEqualTo(0));
+    }
+
+    @Test
+    @RepeatedTest(5)
+    public void canOverrideDefaultDoubleRangeByProgrammaticExtensionRegistration(
+            @Random(type = Double.class) Double anyDouble) throws Exception {
+        assertThat(anyDouble, notNullValue());
+        assertThat(anyDouble, lessThanOrEqualTo(10.0));
+    }
+
+    @Test
+    @RepeatedTest(5)
+    public void canOverrideDefaultMaxLengthOfStringByProgrammaticExtensionRegistration(
+            @Random(type = String.class) String anySting) throws Exception {
+        assertThat(anySting, notNullValue());
+        assertThat(anySting.length(), lessThanOrEqualTo(5));
+    }
+
+    @Test
+    @DisplayName("Should Inject Random values with random bean default behaviour if no Overrides are provided")
+    public void canInjectAttributesIfNoOverridesAreProvided(@Random Long someRandomLong) throws Exception {
+        assertThat(someRandomLong, notNullValue());
+    }
+
+    @Test
+    public void canInjectAPartiallyPopulatedRandomObjectWithProgrammaticExtensionRegistration(@Random DomainObject domainObject) {
+        assertThat(domainObject.getWotsits(), nullValue());
+    }
+
+    @Test
+    public void canInjectARandomListOfDefaultSizeWithProgrammaticExtensionRegistration(@Random(type = String.class) List<String> anyList)
+            throws Exception {
+        assertThat(anyList, notNullValue());
+        assertThat(anyList, not(empty()));
+        assertThat(anyList.size(), is(getDefaultSizeOfRandom()));
+    }
+
+    @Test
+    public void canInjectARandomListOfSpecificSizeWithProgrammaticExtensionRegistration(
+            @Random(size = 5, type = String.class) List<String> anyListOfSpecificSize) {
+        assertThat(anyListOfSpecificSize, notNullValue());
+        assertThat(anyListOfSpecificSize.size(), is(5));
+    }
+
+    @Test
+    public void canInjectARandomSetWithProgrammaticExtensionRegistration(@Random(type = String.class) Set<String> anySet)
+            throws Exception {
+        assertThat(anySet, notNullValue());
+        assertThat(anySet, not(empty()));
+        assertThat(anySet.size(), is(getDefaultSizeOfRandom()));
+    }
+
+    @Test
+    public void canInjectARandomStreamWithProgrammaticExtensionRegistration(@Random(type = String.class) Stream<String> anyStream)
+            throws Exception {
+        assertThat(anyStream, notNullValue());
+        //noinspection UnnecessaryBoxing
+        assertThat(anyStream.count(), is(Long.valueOf(getDefaultSizeOfRandom())));
+    }
+
+    @Test
+    public void canInjectARandomCollectionWithProgrammaticExtensionRegistration(
+            @Random(type = String.class) Collection<String> anyCollection) throws Exception {
+        assertThat(anyCollection, notNullValue());
+        assertThat(anyCollection, not(empty()));
+        assertThat(anyCollection.size(), is(getDefaultSizeOfRandom()));
+    }
+
+
+    @RepeatedTest(5)
+    public void willInjectANewRandomValueEachTimeWithProgrammaticExtensionRegistration(@Random String anyString) {
+        System.out.println(anyString);
+        assertThat(anyString, notNullValue());
+
+        if (anyStrings.isEmpty()) {
+            anyStrings.add(anyString);
+        } else {
+            assertThat(
+                    "Received the same value twice, expected each random value to be different!",
+                    anyStrings,
+                    not(hasItem(anyString)));
+            anyStrings.add(anyString);
+        }
+    }
+}


### PR DESCRIPTION

## Proposed Change
Hello,
Thank you for the wonderful extensions. I am very frequently using these extension specifically  
RandomBeansExtension.

**Problem** 

In many situations, we want to generate random values with certain conditions ( like Integer should be in a range of some value, etc).  easy-random allows this by specifying **Randomization parameters**. 
At present, there is no option to provide these randomization parameters and it's become difficult to use the RandomBeansExtension (Specifically in case there are validation rule implemented ) 

**Proposed Solution**  
Provide an option to accept the Randomization parameters by allowing registering extension using 
`@RegisterExtension`  

Sample Example,
I want to generate Integer in the range of 0 to 10 and Double in range of 0.0 to 10.00   
this is how I can do that 

```
static EnhancedRandom enhancedRandom = EnhancedRandomBuilder
            .aNewEnhancedRandomBuilder()
            .exclude(FieldDefinitionBuilder
                    .field()
                    .named("wotsits")
                    .ofType(List.class)
                    .inClass(DomainObject.class)
                    .get())
            .randomize(Integer.class, IntegerRangeRandomizer.aNewIntegerRangeRandomizer(0, 10))
            .randomize(String.class, StringRandomizer.aNewStringRandomizer(5))
            .randomize(Double.class, DoubleRangeRandomizer.aNewDoubleRangeRandomizer(0.0, 10.0))
            .build();

    @RegisterExtension
    static RandomBeansExtension randomBeansExtension = new RandomBeansExtension(enhancedRandom);

```
*Changes*
I have added a constructor to accept the `EnhancedRandomBuilder `  This also gives the flexibility to accept all the customization supported by easy-random.   

*TestCaes*
1:   Test cases to check if all existing scenarios (Basically existing test cases in Parameter and Field Related test works with Programmatic registration of extension)
2:  Test Cases to check if  Provided overrides work correctly
3:  Test Cases to check if  No overrides are provided it should use easy-random defaults  

*Documentation* 
Updated the user guide for RandomBeansExtension 


## Type Of Change
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ X] I have read the [CONTRIBUTING](/CONTRIBUTING.md) doc
- [ X] All unit tests pass locally with my changes
- [ X] I have added tests that prove my fix is effective or that my feature works
- [ X] I have added necessary documentation (if appropriate)

## Further Comments

If this is a non trivial change then initiate the discussion by explaining why you chose the solution you did and what alternatives you considered etc...